### PR TITLE
Set the binary as entrypoint not command

### DIFF
--- a/ubi-images/Dockerfile.acmesolver
+++ b/ubi-images/Dockerfile.acmesolver
@@ -27,4 +27,4 @@ LABEL name="cert-manager acmesolver" \
       summary="This is the cert-manager ACME HTTP01 solver image." \
       description="This image contains the resolve for ACME HTTP01 challenges."
 
-CMD "/app/cmd/acmesolver/acmesolver"
+ENTRYPOINT "/app/cmd/acmesolver/acmesolver"

--- a/ubi-images/Dockerfile.cainjector
+++ b/ubi-images/Dockerfile.cainjector
@@ -28,4 +28,4 @@ LABEL name="cert-manager cainjector" \
       description="This image contains the cert-manager cainjector."
 
 
-CMD "/app/cmd/cainjector/cainjector"
+ENTRYPOINT "/app/cmd/cainjector/cainjector"

--- a/ubi-images/Dockerfile.controller
+++ b/ubi-images/Dockerfile.controller
@@ -27,4 +27,4 @@ LABEL name="cert-manager controller" \
       summary="This is the cert-manager controller image." \
       description="This image contains the main cert-manager controller."
 
-CMD "/app/cmd/controller/controller"
+ENTRYPOINT "/app/cmd/controller/controller"

--- a/ubi-images/Dockerfile.webhook
+++ b/ubi-images/Dockerfile.webhook
@@ -27,4 +27,4 @@ LABEL name="cert-manager webhook" \
       summary="This is the cert-manager webhook image." \
       description="This image contains the webhook server for cert-manager."
 
-CMD "/app/cmd/webhook/webhook"
+ENTRYPOINT "/app/cmd/webhook/webhook"


### PR DESCRIPTION
The deployment manifests only specify `args` which in the UBI image is pointing to bash.
This sets up the entrypoint of the containers correct.