### PR TITLE
Use OpenShift 4.6 compatible webhook certificate paths

### DIFF
--- a/github.com/operator-framework/community-operators/1.3.1/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.3.1/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.3.1
-    createdAt: '2021-07-30T16:27:02'
+    createdAt: '2021-11-09T14:26:53'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -637,8 +637,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.4.0/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.4.0/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.4.0
-    createdAt: '2021-07-30T16:26:41'
+    createdAt: '2021-11-09T14:26:40'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -677,8 +677,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.4.1/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.4.1/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.4.1
-    createdAt: '2021-07-30T16:26:19'
+    createdAt: '2021-11-09T14:26:26'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -677,8 +677,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.4.2/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.4.2/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.4.2
-    createdAt: '2021-08-11T12:13:40'
+    createdAt: '2021-11-09T14:26:11'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -677,8 +677,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.4.3/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.4.3/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.4.3
-    createdAt: '2021-08-11T12:44:16'
+    createdAt: '2021-11-09T14:25:57'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -677,8 +677,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.4.4/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.4.4/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.4.4
-    createdAt: '2021-08-26T09:17:54'
+    createdAt: '2021-11-09T14:25:43'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -677,8 +677,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.5.3/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.5.3/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.5.3
-    createdAt: '2021-08-26T10:02:38'
+    createdAt: '2021-11-09T14:25:29'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -701,8 +701,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.5.4/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.5.4/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.5.4
-    createdAt: '2021-10-07T09:25:19'
+    createdAt: '2021-11-09T14:25:16'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -701,8 +701,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.6.0/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.6.0/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.0
-    createdAt: '2021-10-28T08:08:57'
+    createdAt: '2021-11-09T14:25:02'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -647,8 +647,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/github.com/operator-framework/community-operators/1.6.1/manifests/cert-manager.clusterserviceversion.yaml
+++ b/github.com/operator-framework/community-operators/1.6.1/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2021-11-09T11:29:34'
+    createdAt: '2021-11-09T14:17:03'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -647,8 +647,8 @@ spec:
                 - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
                 - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
                 - --dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc
-                - --tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
-                - --tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
+                - --tls-cert-file=/apiserver.local.config/certificates/apiserver.crt
+                - --tls-private-key-file=/apiserver.local.config/certificates/apiserver.key
                 env:
                 - name: POD_NAMESPACE
                   valueFrom:

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -111,8 +111,10 @@ def main():
             # Add the arguments back with the modified values
             args.extend([
                 "--dynamic-serving-dns-names=cert-manager-webhook-service.$(POD_NAMESPACE).svc",
-                "--tls-cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt",
-                "--tls-private-key-file=/tmp/k8s-webhook-server/serving-certs/tls.key",
+                # Use certificate paths that are compatible with OpenShift 4.6:
+                # https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
+                "--tls-cert-file=/apiserver.local.config/certificates/apiserver.crt",
+                "--tls-private-key-file=/apiserver.local.config/certificates/apiserver.key",
             ])
             container["args"] = args
 


### PR DESCRIPTION
Fixes: https://github.com/jetstack/cert-manager-olm/issues/33

Tested on OpenShift 4.6 and confirmed that the webhook certificate is now mounted at the backwards compatible path and that the certificates are mounted:

```sh
[crc@crc-4-6 ~]$ oc get catalogsource  -n openshift-marketplace cert-manager-test-catalog -o yaml 
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"operators.coreos.com/v1alpha1","kind":"CatalogSource","metadata":{"annotations":{},"name":"cert-manager-test-catalog","namespace":"openshift-marketplace"},"spec":{"image":"gcr.io/jetstack-richard/cert-manager-olm-catalogue:v1.6.0-8-gb0bf18b","sourceType":"grpc"}}
  creationTimestamp: "2021-11-04T04:00:10Z"
  generation: 2
  name: cert-manager-test-catalog
  namespace: openshift-marketplace
  resourceVersion: "96252"
  selfLink: /apis/operators.coreos.com/v1alpha1/namespaces/openshift-marketplace/catalogsources/cert-manager-test-catalog
  uid: 4e68ed2a-8f23-4b7b-957b-a8217c2bd312
spec:
  image: gcr.io/jetstack-richard/cert-manager-olm-catalogue:v1.6.1-2-ge5a8721-dirty
  sourceType: grpc
status:
  connectionState:
    address: cert-manager-test-catalog.openshift-marketplace.svc:50051
    lastConnect: "2021-11-09T17:55:22Z"
    lastObservedState: READY
  registryService:
    createdAt: "2021-11-09T17:50:37Z"
    port: "50051"
    protocol: grpc
    serviceName: cert-manager-test-catalog
    serviceNamespace: openshift-marketplace


```

```sh
[crc@crc-4-6 ~]$ oc  -n openshift-operators logs deployment.apps/cert-manager-webhook
W1109 17:52:14.968479       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I1109 17:52:14.998002       1 webhook.go:58] cert-manager/webhook "msg"="using TLS certificate from local filesystem"  "certificate"="/apiserver.local.config/certificates/apiserver.crt" "private_key_path"="/apiserver.local.config/certificates/apiserver.key"
I1109 17:52:14.999643       1 server.go:140] cert-manager/webhook "msg"="listening for insecure healthz connections"  "address"=":6080"
I1109 17:52:14.999948       1 server.go:171] cert-manager/webhook "msg"="listening for secure connections"  "address"=":10250"
I1109 17:52:15.000346       1 server.go:203] cert-manager/webhook "msg"="registered pprof handlers"  
I1109 17:52:15.000715       1 file_source.go:144] cert-manager/webhook "msg"="detected private key or certificate data on disk has changed. reloading certificate"  
```