### PR TITLE
Hide internal APIs from the OperatorHub UI

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -36,8 +36,13 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-08T17:42:41'
+    createdAt: '2022-02-15T21:48:43'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    operators.operatorframework.io/internal-objects: |-
+      [
+          "challenge.acme.cert-manager.io",
+          "order.acme.cert-manager.io"
+      ]
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -21,6 +21,7 @@ Important ClusterServiceVersion (CSV) file references:
 """
 import argparse
 import base64
+import json
 import mimetypes
 import sys
 from datetime import datetime
@@ -67,6 +68,14 @@ def main():
         for arch in conf["architectures"]
     })
 
+    # Hide some internal APIs from the OperatorHub UI
+    # https://docs.okd.io/4.9/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs
+    doc["metadata"]["annotations"]["operators.operatorframework.io/internal-objects"] = literal(
+        json.dumps([
+            "challenge.acme.cert-manager.io",
+            "order.acme.cert-manager.io",
+        ], indent=4)
+    )
     doc["metadata"]["annotations"]["capabilities"] = conf["capabilities"]
     doc["metadata"]["annotations"]["categories"] = ",".join(conf["categories"])
     doc["metadata"]["annotations"]["containerImage"] = doc["spec"]["install"]["spec"]["deployments"][0]["spec"]["template"]["spec"]["containers"][0]["image"]


### PR DESCRIPTION
See 
 * https://docs.okd.io/4.9/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs

Unfortunately, this won't hide these types from OperatorHub.io
 *  https://github.com/k8s-operatorhub/operatorhub.io/issues/14