### PR TITLE
Add missing API examples

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -47,12 +47,28 @@ metadata:
             "name": "example-certificaterequest"
           },
           "spec": {}
+        },
+        {
+          "apiVersion": "acme.cert-manager.io/v1",
+          "kind": "Order",
+          "metadata": {
+            "name": "example-order"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "acme.cert-manager.io/v1",
+          "kind": "Challenge",
+          "metadata": {
+            "name": "example-challenge"
+          },
+          "spec": {}
         }
       ]
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:09:42'
+    createdAt: '2022-02-15T22:11:24'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -2,41 +2,41 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: |
+    alm-examples: |-
       [
         {
-            "apiVersion": "cert-manager.io/v1",
-            "kind": "Issuer",
-            "metadata": {
-                "name": "test-selfsigned",
-                "namespace": "cert-manager-test"
-            },
-            "spec": {
-                "selfSigned": {}
-            }
+          "apiVersion": "cert-manager.io/v1",
+          "kind": "Issuer",
+          "metadata": {
+            "name": "test-selfsigned",
+            "namespace": "cert-manager-test"
+          },
+          "spec": {
+            "selfSigned": {}
+          }
         },
         {
-            "apiVersion": "cert-manager.io/v1",
-            "kind": "Certificate",
-            "metadata": {
-                "name": "selfsigned-cert",
-                "namespace": "cert-manager-test"
-            },
-            "spec": {
-                "dnsNames": [
-                    "example.com"
-                ],
-                "issuerRef": {
-                    "name": "test-selfsigned"
-                },
-                "secretName": "selfsigned-cert-tls"
+          "apiVersion": "cert-manager.io/v1",
+          "kind": "Certificate",
+          "metadata": {
+            "name": "selfsigned-cert",
+            "namespace": "cert-manager-test"
+          },
+          "spec": {
+            "dnsNames": [
+              "example.com"
+            ],
+            "issuerRef": {
+              "name": "test-selfsigned",
+              "secretName": "selfsigned-cert-tls"
             }
+          }
         }
       ]
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T21:48:43'
+    createdAt: '2022-02-15T22:01:56'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "cert-manager.io/v1",
           "kind": "Issuer",
           "metadata": {
-            "name": "test-selfsigned"
+            "name": "example-issuer"
           },
           "spec": {
             "selfSigned": {}
@@ -18,23 +18,23 @@ metadata:
           "apiVersion": "cert-manager.io/v1",
           "kind": "Certificate",
           "metadata": {
-            "name": "selfsigned-cert"
+            "name": "example-certificate"
           },
           "spec": {
             "dnsNames": [
               "example.com"
             ],
             "issuerRef": {
-              "name": "test-selfsigned",
-              "secretName": "selfsigned-cert-tls"
-            }
+              "name": "example-issuer"
+            },
+            "secretName": "example-certificate-tls"
           }
         }
       ]
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:05:16'
+    createdAt: '2022-02-15T22:07:26'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -8,8 +8,7 @@ metadata:
           "apiVersion": "cert-manager.io/v1",
           "kind": "Issuer",
           "metadata": {
-            "name": "test-selfsigned",
-            "namespace": "cert-manager-test"
+            "name": "test-selfsigned"
           },
           "spec": {
             "selfSigned": {}
@@ -19,8 +18,7 @@ metadata:
           "apiVersion": "cert-manager.io/v1",
           "kind": "Certificate",
           "metadata": {
-            "name": "selfsigned-cert",
-            "namespace": "cert-manager-test"
+            "name": "selfsigned-cert"
           },
           "spec": {
             "dnsNames": [
@@ -36,7 +34,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:01:56'
+    createdAt: '2022-02-15T22:05:16'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -39,12 +39,20 @@ metadata:
             },
             "secretName": "example-certificate-tls"
           }
+        },
+        {
+          "apiVersion": "cert-manager.io/v1",
+          "kind": "CertificateRequest",
+          "metadata": {
+            "name": "example-certificaterequest"
+          },
+          "spec": {}
         }
       ]
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:08:11'
+    createdAt: '2022-02-15T22:09:42'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -16,6 +16,16 @@ metadata:
         },
         {
           "apiVersion": "cert-manager.io/v1",
+          "kind": "ClusterIssuer",
+          "metadata": {
+            "name": "example-clusterissuer"
+          },
+          "spec": {
+            "selfSigned": {}
+          }
+        },
+        {
+          "apiVersion": "cert-manager.io/v1",
           "kind": "Certificate",
           "metadata": {
             "name": "example-certificate"
@@ -34,7 +44,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:07:26'
+    createdAt: '2022-02-15T22:08:11'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -95,6 +95,12 @@ alm_examples:
   spec:
     selfSigned: {}
 - apiVersion: "cert-manager.io/v1"
+  kind: "ClusterIssuer"
+  metadata:
+    name: "example-clusterissuer"
+  spec:
+    selfSigned: {}
+- apiVersion: "cert-manager.io/v1"
   kind: "Certificate"
   metadata:
     name: "example-certificate"

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -110,6 +110,11 @@ alm_examples:
     issuerRef:
       name: "example-issuer"
     secretName: "example-certificate-tls"
+- apiVersion: "cert-manager.io/v1"
+  kind: "CertificateRequest"
+  metadata:
+    name: "example-certificaterequest"
+  spec: {}
 
 
 # A list of architectures for which there are cert-manager Docker images.

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -115,6 +115,16 @@ alm_examples:
   metadata:
     name: "example-certificaterequest"
   spec: {}
+- apiVersion: "acme.cert-manager.io/v1"
+  kind: "Order"
+  metadata:
+    name: "example-order"
+  spec: {}
+- apiVersion: "acme.cert-manager.io/v1"
+  kind: "Challenge"
+  metadata:
+    name: "example-challenge"
+  spec: {}
 
 
 # A list of architectures for which there are cert-manager Docker images.

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -87,37 +87,26 @@ maintainers:
 - name: The cert-manager maintainers
   email: cert-manager-maintainers@googlegroups.com
 
-alm_examples: |
-  [
-    {
-        "apiVersion": "cert-manager.io/v1",
-        "kind": "Issuer",
-        "metadata": {
-            "name": "test-selfsigned",
-            "namespace": "cert-manager-test"
-        },
-        "spec": {
-            "selfSigned": {}
-        }
-    },
-    {
-        "apiVersion": "cert-manager.io/v1",
-        "kind": "Certificate",
-        "metadata": {
-            "name": "selfsigned-cert",
-            "namespace": "cert-manager-test"
-        },
-        "spec": {
-            "dnsNames": [
-                "example.com"
-            ],
-            "issuerRef": {
-                "name": "test-selfsigned"
-            },
-            "secretName": "selfsigned-cert-tls"
-        }
-    }
-  ]
+alm_examples:
+- apiVersion: "cert-manager.io/v1"
+  kind: "Issuer"
+  metadata:
+    name: "test-selfsigned"
+    namespace: "cert-manager-test"
+  spec:
+    selfSigned: {}
+- apiVersion: "cert-manager.io/v1"
+  kind: "Certificate"
+  metadata:
+    name: "selfsigned-cert"
+    namespace: "cert-manager-test"
+  spec:
+    dnsNames:
+    - "example.com"
+    issuerRef:
+      name: "test-selfsigned"
+      secretName: "selfsigned-cert-tls"
+
 
 # A list of architectures for which there are cert-manager Docker images.
 # TODO: In future we should add arm (ARCH) and darwin and windows (OS)

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -91,19 +91,19 @@ alm_examples:
 - apiVersion: "cert-manager.io/v1"
   kind: "Issuer"
   metadata:
-    name: "test-selfsigned"
+    name: "example-issuer"
   spec:
     selfSigned: {}
 - apiVersion: "cert-manager.io/v1"
   kind: "Certificate"
   metadata:
-    name: "selfsigned-cert"
+    name: "example-certificate"
   spec:
     dnsNames:
     - "example.com"
     issuerRef:
-      name: "test-selfsigned"
-      secretName: "selfsigned-cert-tls"
+      name: "example-issuer"
+    secretName: "example-certificate-tls"
 
 
 # A list of architectures for which there are cert-manager Docker images.

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -92,14 +92,12 @@ alm_examples:
   kind: "Issuer"
   metadata:
     name: "test-selfsigned"
-    namespace: "cert-manager-test"
   spec:
     selfSigned: {}
 - apiVersion: "cert-manager.io/v1"
   kind: "Certificate"
   metadata:
     name: "selfsigned-cert"
-    namespace: "cert-manager-test"
   spec:
     dnsNames:
     - "example.com"

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -82,7 +82,7 @@ def main():
     doc["metadata"]["annotations"]["createdAt"] = datetime.utcnow().isoformat(timespec="seconds")
     doc["metadata"]["annotations"]["support"] = conf["support"]
     doc["metadata"]["annotations"]["repository"] = conf["repository"]
-    doc["metadata"]["annotations"]["alm-examples"] = literal(conf["alm_examples"])
+    doc["metadata"]["annotations"]["alm-examples"] = literal(json.dumps(conf["alm_examples"], indent=2))
     doc["spec"]["icon"] = [{
         "base64data": logo_b64.decode("ascii"),
         "mediatype": logo_type,


### PR DESCRIPTION
Fixes the following warnings:

```
operator-sdk-1.17.0 bundle validate --select-optional suite=operatorframework ./bundle
WARN[0000] Warning: Value cert-manager.io/v1, Kind=CertificateRequest: provided API should have an example annotation 
WARN[0000] Warning: Value acme.cert-manager.io/v1, Kind=Challenge: provided API should have an example annotation 
WARN[0000] Warning: Value acme.cert-manager.io/v1, Kind=Order: provided API should have an example annotation 

```