### PR TITLE
Add CRD display names and descriptions

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,7 +68,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-16T07:10:44'
+    createdAt: '2022-02-16T07:26:24'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [
@@ -89,27 +89,47 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - displayName: CertificateRequest
+    - description: "A CertificateRequest is used to request a signed certificate from\
+        \ one of the configured issuers. \n All fields within the CertificateRequest's\
+        \ `spec` are immutable after creation. A CertificateRequest will either succeed\
+        \ or fail, as denoted by its `status.state` field. \n A CertificateRequest\
+        \ is a one-shot resource, meaning it represents a single point in time request\
+        \ for a certificate and cannot be re-used."
+      displayName: CertificateRequest
       kind: CertificateRequest
       name: certificaterequests.cert-manager.io
       version: v1
-    - displayName: Certificate
+    - description: "A Certificate resource should be created to ensure an up to date\
+        \ and signed x509 certificate is stored in the Kubernetes Secret resource\
+        \ named in `spec.secretName`. \n The stored certificate will be renewed before\
+        \ it expires (as configured by `spec.renewBefore`)."
+      displayName: Certificate
       kind: Certificate
       name: certificates.cert-manager.io
       version: v1
-    - displayName: Challenge
+    - description: Challenge is a type to represent a Challenge request with an ACME
+        server
+      displayName: Challenge
       kind: Challenge
       name: challenges.acme.cert-manager.io
       version: v1
-    - displayName: ClusterIssuer
+    - description: A ClusterIssuer represents a certificate issuing authority which
+        can be referenced as part of `issuerRef` fields. It is similar to an Issuer,
+        however it is cluster-scoped and therefore can be referenced by resources
+        that exist in *any* namespace, not just the same namespace as the referent.
+      displayName: ClusterIssuer
       kind: ClusterIssuer
       name: clusterissuers.cert-manager.io
       version: v1
-    - displayName: Issuer
+    - description: An Issuer represents a certificate issuing authority which can
+        be referenced as part of `issuerRef` fields. It is scoped to a single namespace
+        and can therefore only be referenced by resources within the same namespace.
+      displayName: Issuer
       kind: Issuer
       name: issuers.cert-manager.io
       version: v1
-    - displayName: Order
+    - description: Order is a type to represent an Order with an ACME server
+      displayName: Order
       kind: Order
       name: orders.acme.cert-manager.io
       version: v1

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,12 +68,12 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-16T07:26:24'
+    createdAt: '2022-02-16T09:25:32'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [
-          "challenge.acme.cert-manager.io",
-          "order.acme.cert-manager.io"
+        "challenges.acme.cert-manager.io",
+        "orders.acme.cert-manager.io"
       ]
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
@@ -109,7 +109,7 @@ spec:
       version: v1
     - description: Challenge is a type to represent a Challenge request with an ACME
         server
-      displayName: Challenge
+      displayName: (Internal) Challenge
       kind: Challenge
       name: challenges.acme.cert-manager.io
       version: v1
@@ -129,7 +129,7 @@ spec:
       name: issuers.cert-manager.io
       version: v1
     - description: Order is a type to represent an Order with an ACME server
-      displayName: Order
+      displayName: (Internal) Order
       kind: Order
       name: orders.acme.cert-manager.io
       version: v1

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,7 +68,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-15T22:11:24'
+    createdAt: '2022-02-16T07:10:44'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/internal-objects: |-
       [
@@ -89,22 +89,28 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: CertificateRequest
+    - displayName: CertificateRequest
+      kind: CertificateRequest
       name: certificaterequests.cert-manager.io
       version: v1
-    - kind: Certificate
+    - displayName: Certificate
+      kind: Certificate
       name: certificates.cert-manager.io
       version: v1
-    - kind: Challenge
+    - displayName: Challenge
+      kind: Challenge
       name: challenges.acme.cert-manager.io
       version: v1
-    - kind: ClusterIssuer
+    - displayName: ClusterIssuer
+      kind: ClusterIssuer
       name: clusterissuers.cert-manager.io
       version: v1
-    - kind: Issuer
+    - displayName: Issuer
+      kind: Issuer
       name: issuers.cert-manager.io
       version: v1
-    - kind: Order
+    - displayName: Order
+      kind: Order
       name: orders.acme.cert-manager.io
       version: v1
   description: |

--- a/global-csv-config.yaml
+++ b/global-csv-config.yaml
@@ -138,3 +138,9 @@ architectures:
   - arm64
   - ppc64le
   - s390x
+
+# A list of Kind.Group which are considered "internal-objects".
+# See https://docs.okd.io/4.9/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs
+internal_objects:
+  - "challenges.acme.cert-manager.io"
+  - "orders.acme.cert-manager.io"

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -61,14 +61,22 @@ def main():
         conf = yaml.safe_load(config_file)
     doc = yaml.safe_load(sys.stdin)
 
+    internal_objects = conf["internal_objects"]
+
     # Add displayName for the CRD preview in operatorhub.io.
+    # Add an (Internal) prefix to the kinds that are internal-objects.
     # Ideally operatorhub.io would just use the existing CRD name and
     # description.
     # See https://github.com/k8s-operatorhub/operatorhub.io/issues/2
     for crd in doc["spec"]["customresourcedefinitions"]["owned"]:
-        crd["displayName"] = crd["kind"]
-        kind, group = crd["name"].split(".", 1)
-        crdContent = yaml.safe_load(open(f"bundle/manifests/{group}_{kind}.yaml"))
+        kindAndGroup = crd["name"]
+        displayName = crd["kind"]
+        if kindAndGroup in internal_objects:
+            displayName = f"(Internal) {displayName}"
+        crd["displayName"] = displayName
+        kind, group = kindAndGroup.split(".", 1)
+        with open(f"bundle/manifests/{group}_{kind}.yaml") as f:
+            crdContent = yaml.safe_load(f)
         crd["description"] = crdContent["spec"]["versions"][-1]["schema"]["openAPIV3Schema"]["description"]
 
     # Add multiarch labels.
@@ -78,13 +86,13 @@ def main():
         for arch in conf["architectures"]
     })
 
-    # Hide some internal APIs from the OperatorHub UI
-    # https://docs.okd.io/4.9/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs
+    # Hide some internal APIs from the OperatorHub UI.
+    # See https://docs.okd.io/4.9/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs
+    # Ideally these would be hidden from the WebUI in operatorhub.io, but they
+    # are not.
+    # See https://github.com/k8s-operatorhub/operatorhub.io/issues/14
     doc["metadata"]["annotations"]["operators.operatorframework.io/internal-objects"] = literal(
-        json.dumps([
-            "challenge.acme.cert-manager.io",
-            "order.acme.cert-manager.io",
-        ], indent=4)
+        json.dumps(internal_objects, indent=2)
     )
     doc["metadata"]["annotations"]["capabilities"] = conf["capabilities"]
     doc["metadata"]["annotations"]["categories"] = ",".join(conf["categories"])

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -61,6 +61,13 @@ def main():
         conf = yaml.safe_load(config_file)
     doc = yaml.safe_load(sys.stdin)
 
+    # Add displayName for the CRD preview in operatorhub.io.
+    # Ideally operatorhub.io would just use the existing CRD name and
+    # description.
+    # See https://github.com/k8s-operatorhub/operatorhub.io/issues/2
+    for crd in doc["spec"]["customresourcedefinitions"]["owned"]:
+        crd["displayName"] = crd["kind"]
+
     # Add multiarch labels.
     # See https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/
     doc["metadata"].setdefault("labels", {}).update({

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -67,6 +67,9 @@ def main():
     # See https://github.com/k8s-operatorhub/operatorhub.io/issues/2
     for crd in doc["spec"]["customresourcedefinitions"]["owned"]:
         crd["displayName"] = crd["kind"]
+        kind, group = crd["name"].split(".", 1)
+        crdContent = yaml.safe_load(open(f"bundle/manifests/{group}_{kind}.yaml"))
+        crd["description"] = crdContent["spec"]["versions"][-1]["schema"]["openAPIV3Schema"]["description"]
 
     # Add multiarch labels.
     # See https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/


### PR DESCRIPTION
This fills out the CRD tiles on operatorhub.io

![image](https://user-images.githubusercontent.com/978965/154235130-51765835-c4ea-4654-8e02-75b907a84946.png)

Ideally operatorhub.io would do this
* https://github.com/k8s-operatorhub/operatorhub.io/issues/2
* https://github.com/k8s-operatorhub/operatorhub.io/issues/14