### PR TITLE
Upgrade to opm 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CERT_MANAGER_LOGO_URL ?= https://github.com/cert-manager/website/raw/3998bef91af
 KUSTOMIZE_VERSION ?= 4.4.0
 KIND_VERSION ?= 0.11.1
 OPERATOR_SDK_VERSION ?= 1.17.0
-OPM_VERSION ?= 1.19.1
+OPM_VERSION ?= 1.20.0
 
 bin := bin
 os := $(shell go env GOOS)


### PR DESCRIPTION
See https://github.com/operator-framework/operator-registry/releases/tag/v1.20.0

It doesn't change anything in the bundle but I wanted to experiment with some of the commands related to https://olm.operatorframework.io/docs/reference/file-based-catalogs/