### PR TITLE
Add cert-manager v1.6.2 as a release-candidate to a candidates channel for testing  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ subscription-deploy:
 
 .PHONY: bundle-validate
 bundle-validate: ## Run static checks
-bundle-validate: ${bundle_csv} ${operator_sdk}
+bundle-validate: ${operator_sdk}
 	${operator_sdk} bundle validate ${bundle_dir} --select-optional suite=operatorframework
 
 .PHONY: deploy-olm

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL := bash
 .SUFFIXES:
 .ONESHELL:
 
-CERT_MANAGER_VERSION ?= 1.6.1
-BUNDLE_VERSION ?= ${CERT_MANAGER_VERSION}
+CERT_MANAGER_VERSION ?= 1.6.2
+BUNDLE_VERSION ?= ${CERT_MANAGER_VERSION}-rc1
 CATALOG_VERSION ?= $(shell git describe --tags --always --dirty)
 OPERATORHUB_CATALOG_IMAGE ?= quay.io/operatorhubio/catalog:latest
 
@@ -101,7 +101,7 @@ ${bundle_osdk_csv}: ${operator_sdk} ${kustomize_config} ${kustomize}
 	cd ${bundle_osdk_dir}
 	$(abspath ${kustomize}) build $(abspath ${kustomize_config_dir}) | $(abspath ${operator_sdk}) generate bundle \
 		--verbose \
-		--channels stable \
+		--channels candidate \
 		--default-channel stable \
 		--package ${OLM_PACKAGE_NAME} \
 		--version ${BUNDLE_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ metadata:
  name: cert-manager-subscription
  namespace: operators
 spec:
- channel: stable
+ channel: $(firstword ${BUNDLE_CHANNELS})
  name: cert-manager
  source: cert-manager-test-catalog
  sourceNamespace: olm

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ SHELL := bash
 
 CERT_MANAGER_VERSION ?= 1.6.2
 BUNDLE_VERSION ?= ${CERT_MANAGER_VERSION}-rc1
+BUNDLE_CHANNELS ?= candidate
+STABLE_CHANNEL ?= stable
 CATALOG_VERSION ?= $(shell git describe --tags --always --dirty)
 OPERATORHUB_CATALOG_IMAGE ?= quay.io/operatorhubio/catalog:latest
 
@@ -28,6 +30,10 @@ KUSTOMIZE_VERSION ?= 4.4.0
 KIND_VERSION ?= 0.11.1
 OPERATOR_SDK_VERSION ?= 1.17.0
 OPM_VERSION ?= 1.20.0
+
+comma := ,
+empty :=
+space := $(empty) $(empty)
 
 bin := bin
 os := $(shell go env GOOS)
@@ -101,8 +107,8 @@ ${bundle_osdk_csv}: ${operator_sdk} ${kustomize_config} ${kustomize}
 	cd ${bundle_osdk_dir}
 	$(abspath ${kustomize}) build $(abspath ${kustomize_config_dir}) | $(abspath ${operator_sdk}) generate bundle \
 		--verbose \
-		--channels candidate \
-		--default-channel stable \
+		--channels $(subst $(space),$(comma),${BUNDLE_CHANNELS}) \
+		--default-channel=$(filter ${STABLE_CHANNEL},${BUNDLE_CHANNELS}) \
 		--package ${OLM_PACKAGE_NAME} \
 		--version ${BUNDLE_VERSION} \
 		--output-dir .

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -5,9 +5,9 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channels.v1=candidate
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown
 

--- a/bundle/bundle.Dockerfile
+++ b/bundle/bundle.Dockerfile
@@ -6,7 +6,6 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager
 LABEL operators.operatorframework.io.bundle.channels.v1=candidate
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown

--- a/bundle/manifests/acme.cert-manager.io_challenges.yaml
+++ b/bundle/manifests/acme.cert-manager.io_challenges.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/acme.cert-manager.io_orders.yaml
+++ b/bundle/manifests/acme.cert-manager.io_orders.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cert-manager-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/bundle/manifests/cert-manager-webhook_v1_service.yaml
+++ b/bundle/manifests/cert-manager-webhook_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 spec:
   ports:

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -67,9 +67,9 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Security
-    containerImage: quay.io/jetstack/cert-manager-controller:v1.6.1
-    createdAt: '2022-02-16T09:25:32'
-    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    containerImage: quay.io/jetstack/cert-manager-controller:v1.6.2
+    createdAt: '2022-02-16T14:11:18'
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/internal-objects: |-
       [
         "challenges.acme.cert-manager.io",
@@ -83,7 +83,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: cert-manager.v1.6.1
+  name: cert-manager.v1.6.2-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -634,7 +634,7 @@ spec:
                 app.kubernetes.io/component: controller
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cert-manager
-                app.kubernetes.io/version: v1.6.1
+                app.kubernetes.io/version: v1.6.2
             spec:
               containers:
               - args:
@@ -646,7 +646,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-controller:v1.6.1
+                image: quay.io/jetstack/cert-manager-controller:v1.6.2
                 imagePullPolicy: IfNotPresent
                 name: cert-manager
                 ports:
@@ -672,7 +672,7 @@ spec:
                 app.kubernetes.io/component: cainjector
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: cainjector
-                app.kubernetes.io/version: v1.6.1
+                app.kubernetes.io/version: v1.6.2
             spec:
               containers:
               - args:
@@ -683,7 +683,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+                image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
                 imagePullPolicy: IfNotPresent
                 name: cert-manager
                 resources: {}
@@ -706,7 +706,7 @@ spec:
                 app.kubernetes.io/component: webhook
                 app.kubernetes.io/instance: cert-manager
                 app.kubernetes.io/name: webhook
-                app.kubernetes.io/version: v1.6.1
+                app.kubernetes.io/version: v1.6.2
             spec:
               containers:
               - args:
@@ -722,7 +722,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+                image: quay.io/jetstack/cert-manager-webhook:v1.6.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 3
@@ -871,7 +871,7 @@ spec:
   provider:
     name: The cert-manager maintainers
     url: https://cert-manager.io/
-  version: 1.6.1
+  version: 1.6.2-rc1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,7 +68,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.2
-    createdAt: '2022-02-16T15:57:52'
+    createdAt: '2022-02-24T21:11:39'
+    olm.skipRange: '>=1.6.0 <1.6.2-rc1'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -68,7 +68,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Security
     containerImage: quay.io/jetstack/cert-manager-controller:v1.6.2
-    createdAt: '2022-02-16T14:11:18'
+    createdAt: '2022-02-16T15:57:52'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/internal-objects: |-
       [

--- a/bundle/manifests/cert-manager.io_certificaterequests.yaml
+++ b/bundle/manifests/cert-manager.io_certificaterequests.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/cert-manager.io_certificates.yaml
+++ b/bundle/manifests/cert-manager.io_certificates.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/cert-manager.io_clusterissuers.yaml
+++ b/bundle/manifests/cert-manager.io_clusterissuers.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/cert-manager.io_issuers.yaml
+++ b/bundle/manifests/cert-manager.io_issuers.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:

--- a/bundle/manifests/cert-manager_v1_service.yaml
+++ b/bundle/manifests/cert-manager_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
 spec:
   ports:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cert-manager
   operators.operatorframework.io.bundle.channels.v1: candidate
-  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,9 +4,9 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cert-manager
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: candidate
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown
 

--- a/hack/fixup-csv
+++ b/hack/fixup-csv
@@ -26,6 +26,7 @@ import mimetypes
 import sys
 from datetime import datetime
 
+import semver
 import yaml
 
 
@@ -60,6 +61,14 @@ def main():
     with open(args.config) as config_file:
         conf = yaml.safe_load(config_file)
     doc = yaml.safe_load(sys.stdin)
+
+    # If this is a patch release, add skiprange so that it is installed in
+    # preference to all previous patch versions (skip patch), even across
+    # channels.
+    # See https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange
+    v = semver.parse_version_info(doc["spec"]["version"])
+    if v.patch:
+        doc["metadata"]["annotations"]["olm.skipRange"] = f">={v.major}.{v.minor}.0 <{v}"
 
     internal_objects = conf["internal_objects"]
 


### PR DESCRIPTION
I'll submit this in https://github.com/k8s-operatorhub/community-operators and let them merge it and I hope that then I'll be able to test the catalog produced by them by subscribing to the candidates channel.
As opposed to trying to create my own catalog image and make it available to CRC etc.

Downstream PRs:
 * https://github.com/k8s-operatorhub/community-operators/pull/780
 * https://github.com/k8s-operatorhub/community-operators/pull/820
 * https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/827